### PR TITLE
[MIG] connector_magento to v11

### DIFF
--- a/connector_magento/__init__.py
+++ b/connector_magento/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2013 Guewen Baconnier,Camptocamp SA,Akretion
 # © 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).

--- a/connector_magento/__manifest__.py
+++ b/connector_magento/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2013 Guewen Baconnier,Camptocamp SA,Akretion
 # © 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).

--- a/connector_magento/components/__init__.py
+++ b/connector_magento/components/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from . import core
 from . import backend_adapter
 from . import binder

--- a/connector_magento/components/backend_adapter.py
+++ b/connector_magento/components/backend_adapter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
@@ -75,9 +74,9 @@ class MagentoAPI(object):
         # we do nothing, api is lazy
         return self
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, exc_type, exc_value, traceback):
         if self._api is not None:
-            self._api.__exit__(type, value, traceback)
+            self._api.__exit__(exc_type, exc_value, traceback)
 
     def call(self, method, arguments):
         try:
@@ -121,6 +120,7 @@ class MagentoAPI(object):
 
 class MagentoCRUDAdapter(AbstractComponent):
     """ External Records Adapter for Magento """
+    # pylint: disable=method-required-super
 
     _name = 'magento.crud.adapter'
     _inherit = ['base.backend.adapter', 'base.magento.connector']
@@ -131,7 +131,7 @@ class MagentoCRUDAdapter(AbstractComponent):
         and returns a list of ids """
         raise NotImplementedError
 
-    def read(self, id, attributes=None):
+    def read(self, external_id, attributes=None):
         """ Returns the information of a record """
         raise NotImplementedError
 
@@ -144,11 +144,11 @@ class MagentoCRUDAdapter(AbstractComponent):
         """ Create a record on the external system """
         raise NotImplementedError
 
-    def write(self, id, data):
+    def write(self, external_id, data):
         """ Update records on the external system """
         raise NotImplementedError
 
-    def delete(self, id):
+    def delete(self, external_id):
         """ Delete a record on the external system """
         raise NotImplementedError
 
@@ -165,6 +165,7 @@ class MagentoCRUDAdapter(AbstractComponent):
 
 
 class GenericAdapter(AbstractComponent):
+    # pylint: disable=method-required-super
 
     _name = 'magento.adapter'
     _inherit = 'magento.crud.adapter'
@@ -181,12 +182,12 @@ class GenericAdapter(AbstractComponent):
         return self._call('%s.search' % self._magento_model,
                           [filters] if filters else [{}])
 
-    def read(self, id, attributes=None):
+    def read(self, external_id, attributes=None):
         """ Returns the information of a record
 
         :rtype: dict
         """
-        arguments = [int(id)]
+        arguments = [int(external_id)]
         if attributes:
             # Avoid to pass Null values in attributes. Workaround for
             # https://bugs.launchpad.net/openerp-connector-magento/+bug/1210775
@@ -209,16 +210,17 @@ class GenericAdapter(AbstractComponent):
         """ Create a record on the external system """
         return self._call('%s.create' % self._magento_model, [data])
 
-    def write(self, id, data):
+    def write(self, external_id, data):
         """ Update records on the external system """
         return self._call('%s.update' % self._magento_model,
-                          [int(id), data])
+                          [int(external_id), data])
 
-    def delete(self, id):
+    def delete(self, external_id):
         """ Delete a record on the external system """
-        return self._call('%s.delete' % self._magento_model, [int(id)])
+        return self._call('%s.delete' % self._magento_model,
+                          [int(external_id)])
 
-    def admin_url(self, id):
+    def admin_url(self, external_id):
         """ Return the URL in the Magento admin for a record """
         if self._admin_path is None:
             raise ValueError('No admin path is defined for this record')
@@ -227,7 +229,7 @@ class GenericAdapter(AbstractComponent):
         if not url:
             raise ValueError('No admin URL configured on the backend.')
         path = self._admin_path.format(model=self._magento_model,
-                                       id=id)
+                                       id=external_id)
         url = url.rstrip('/')
         path = path.lstrip('/')
         url = '/'.join((url, path))

--- a/connector_magento/components/binder.py
+++ b/connector_magento/components/binder.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2013 Guewen Baconnier,Camptocamp SA,Akretion
 # © 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).

--- a/connector_magento/components/core.py
+++ b/connector_magento/components/core.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 

--- a/connector_magento/components/deleter.py
+++ b/connector_magento/components/deleter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 

--- a/connector_magento/components/exporter.py
+++ b/connector_magento/components/exporter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2013 Guewen Baconnier,Camptocamp SA,Akretion
 # © 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
@@ -104,6 +103,7 @@ class MagentoBaseExporter(AbstractComponent):
         # The commit will also release the lock acquired on the binding
         # record
         if not odoo.tools.config['test_enable']:
+            # pylint: disable=invalid-commit
             self.env.cr.commit()  # noqa
 
         self._after_export()
@@ -274,6 +274,7 @@ class MagentoExporter(AbstractComponent):
                     # the same binding. It will be caught and
                     # raise a RetryableJobError.
                     if not odoo.tools.config['test_enable']:
+                        # pylint: disable=invalid-commit
                         self.env.cr.commit()  # noqa
         else:
             # If magento_bind_ids does not exist we are typically in a

--- a/connector_magento/components/importer.py
+++ b/connector_magento/components/importer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2013 Guewen Baconnier,Camptocamp SA,Akretion
 # © 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
@@ -188,7 +187,7 @@ class MagentoImporter(AbstractComponent):
         except IDMissingInBackend:
             return _('Record does no longer exist in Magento')
 
-        skip = self._must_skip()
+        skip = self._must_skip()    # pylint: disable=assignment-from-none
         if skip:
             return skip
 

--- a/connector_magento/components/line_builder.py
+++ b/connector_magento/components/line_builder.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2017 Hibou Corp.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 

--- a/connector_magento/components/mapper.py
+++ b/connector_magento/components/mapper.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2013 Guewen Baconnier,Camptocamp SA,Akretion
 # © 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).

--- a/connector_magento/doc/conf.py
+++ b/connector_magento/doc/conf.py
@@ -58,7 +58,7 @@ if os.environ.get('TRAVIS_BUILD_DIR') and os.environ.get('VERSION'):
     # build from travis
     repos_home = os.environ['HOME']
     deps_path = os.path.join(repos_home, 'dependencies')
-    odoo_folder = 'odoo-10.0'
+    odoo_folder = 'odoo-{}'.format(os.environ['VERSION'])
     odoo_root = os.path.join(repos_home, odoo_folder)
     build_path = os.environ['TRAVIS_BUILD_DIR']
 else:

--- a/connector_magento/exception.py
+++ b/connector_magento/exception.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2013 Guewen Baconnier,Camptocamp SA,Akretion
 # © 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).

--- a/connector_magento/models/__init__.py
+++ b/connector_magento/models/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from . import magento_binding  # should be loaded first for inheritance
 
 from . import account_invoice

--- a/connector_magento/models/account_invoice/__init__.py
+++ b/connector_magento/models/account_invoice/__init__.py
@@ -1,3 +1,2 @@
-# -*- coding: utf-8 -*-
 from . import common
 from . import exporter

--- a/connector_magento/models/account_invoice/common.py
+++ b/connector_magento/models/account_invoice/common.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2013-2017 Camptocamp SA
+# Copyright 2013-2019 Camptocamp SA
 # © 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
@@ -81,6 +80,7 @@ class AccountInvoiceAdapter(Component):
     def create(self, order_increment_id, items, comment, email,
                include_comment):
         """ Create a record on the external system """
+        # pylint: disable=method-required-super
         return self._call('%s.create' % self._magento_model,
                           [order_increment_id, items, comment,
                            email, include_comment])

--- a/connector_magento/models/account_invoice/exporter.py
+++ b/connector_magento/models/account_invoice/exporter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 

--- a/connector_magento/models/account_payment_mode/__init__.py
+++ b/connector_magento/models/account_payment_mode/__init__.py
@@ -1,2 +1,1 @@
-# -*- coding: utf-8 -*-
 from . import common

--- a/connector_magento/models/account_payment_mode/common.py
+++ b/connector_magento/models/account_payment_mode/common.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# © 2013-2017 Guewen Baconnier,Camptocamp SA,Akretion
+# © 2013-2019 Guewen Baconnier,Camptocamp SA,Akretion
 # © 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 

--- a/connector_magento/models/delivery/__init__.py
+++ b/connector_magento/models/delivery/__init__.py
@@ -1,2 +1,1 @@
-# -*- coding: utf-8 -*-
 from . import common

--- a/connector_magento/models/delivery/common.py
+++ b/connector_magento/models/delivery/common.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2013 Guewen Baconnier,Camptocamp SA,Akretion
 # © 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).

--- a/connector_magento/models/magento_backend/__init__.py
+++ b/connector_magento/models/magento_backend/__init__.py
@@ -1,3 +1,2 @@
-# -*- coding: utf-8 -*-
 from . import common
 from . import importer

--- a/connector_magento/models/magento_backend/common.py
+++ b/connector_magento/models/magento_backend/common.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2013 Guewen Baconnier,Camptocamp SA,Akretion
 # © 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).

--- a/connector_magento/models/magento_backend/importer.py
+++ b/connector_magento/models/magento_backend/importer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 

--- a/connector_magento/models/magento_binding/__init__.py
+++ b/connector_magento/models/magento_binding/__init__.py
@@ -1,2 +1,1 @@
-# -*- coding: utf-8 -*-
 from . import common

--- a/connector_magento/models/magento_binding/common.py
+++ b/connector_magento/models/magento_binding/common.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# © 2013-2017 Guewen Baconnier,Camptocamp SA,Akretion
+# © 2013-2019 Guewen Baconnier,Camptocamp SA,Akretion
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, models, fields

--- a/connector_magento/models/magento_store/__init__.py
+++ b/connector_magento/models/magento_store/__init__.py
@@ -1,3 +1,2 @@
-# -*- coding: utf-8 -*-
 from . import common
 from . import importer

--- a/connector_magento/models/magento_store/common.py
+++ b/connector_magento/models/magento_store/common.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2013-2017 Camptocamp SA
+# Copyright 2013-2019 Camptocamp SA
 # © 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 

--- a/connector_magento/models/magento_store/importer.py
+++ b/connector_magento/models/magento_store/importer.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2013-2017 Camptocamp SA
+# Copyright 2013-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from odoo.addons.component.core import Component

--- a/connector_magento/models/magento_storeview/__init__.py
+++ b/connector_magento/models/magento_storeview/__init__.py
@@ -1,3 +1,2 @@
-# -*- coding: utf-8 -*-
 from . import common
 from . import importer

--- a/connector_magento/models/magento_storeview/common.py
+++ b/connector_magento/models/magento_storeview/common.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2103-2017 Camptocamp SA
+# Copyright 2103-2019 Camptocamp SA
 # © 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 

--- a/connector_magento/models/magento_storeview/importer.py
+++ b/connector_magento/models/magento_storeview/importer.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2013-2017 Camptocamp SA
+# Copyright 2013-2019 Camptocamp SA
 # © 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 

--- a/connector_magento/models/magento_website/__init__.py
+++ b/connector_magento/models/magento_website/__init__.py
@@ -1,3 +1,2 @@
-# -*- coding: utf-8 -*-
 from . import common
 from . import importer

--- a/connector_magento/models/magento_website/common.py
+++ b/connector_magento/models/magento_website/common.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# © 2013-2017 Guewen Baconnier,Camptocamp SA,Akretion
+# © 2013-2019 Guewen Baconnier,Camptocamp SA,Akretion
 # © 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 

--- a/connector_magento/models/magento_website/importer.py
+++ b/connector_magento/models/magento_website/importer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 

--- a/connector_magento/models/partner/__init__.py
+++ b/connector_magento/models/partner/__init__.py
@@ -1,3 +1,2 @@
-# -*- coding: utf-8 -*-
 from . import common
 from . import importer

--- a/connector_magento/models/partner/common.py
+++ b/connector_magento/models/partner/common.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2013-2017 Camptocamp SA
+# Copyright 2013-2019 Camptocamp SA
 # © 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
@@ -207,5 +206,6 @@ class AddressAdapter(Component):
 
     def create(self, customer_id, data):
         """ Create a record on the external system """
+        # pylint: disable=method-required-super
         return self._call('%s.create' % self._magento_model,
                           [customer_id, data])

--- a/connector_magento/models/partner/importer.py
+++ b/connector_magento/models/partner/importer.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2013-2017 Camptocamp SA
+# Copyright 2013-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 import logging

--- a/connector_magento/models/partner_category/__init__.py
+++ b/connector_magento/models/partner_category/__init__.py
@@ -1,3 +1,2 @@
-# -*- coding: utf-8 -*-
 from . import common
 from . import importer

--- a/connector_magento/models/partner_category/common.py
+++ b/connector_magento/models/partner_category/common.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2013 Guewen Baconnier,Camptocamp SA,Akretion
 # © 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).

--- a/connector_magento/models/partner_category/importer.py
+++ b/connector_magento/models/partner_category/importer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2013-2017 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 

--- a/connector_magento/models/product/__init__.py
+++ b/connector_magento/models/product/__init__.py
@@ -1,3 +1,2 @@
-# -*- coding: utf-8 -*-
 from . import common
 from . import importer

--- a/connector_magento/models/product/common.py
+++ b/connector_magento/models/product/common.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2013-2017 Camptocamp SA
+# Copyright 2013-2019 Camptocamp SA
 # © 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
@@ -217,32 +216,35 @@ class ProductProductAdapter(Component):
                 in self._call('%s.list' % self._magento_model,
                               [filters] if filters else [{}])]
 
-    def read(self, id, storeview_id=None, attributes=None):
+    def read(self, external_id, storeview_id=None, attributes=None):
         """ Returns the information of a record
 
         :rtype: dict
         """
+        # pylint: disable=method-required-super
         return self._call('ol_catalog_product.info',
-                          [int(id), storeview_id, attributes, 'id'])
+                          [int(external_id), storeview_id, attributes, 'id'])
 
-    def write(self, id, data, storeview_id=None):
+    def write(self, external_id, data, storeview_id=None):
         """ Update records on the external system """
+        # pylint: disable=method-required-super
         # XXX actually only ol_catalog_product.update works
         # the PHP connector maybe breaks the catalog_product.update
         return self._call('ol_catalog_product.update',
-                          [int(id), data, storeview_id, 'id'])
+                          [int(external_id), data, storeview_id, 'id'])
 
-    def get_images(self, id, storeview_id=None):
-        return self._call('product_media.list', [int(id), storeview_id, 'id'])
+    def get_images(self, external_id, storeview_id=None):
+        return self._call('product_media.list',
+                          [int(external_id), storeview_id, 'id'])
 
-    def read_image(self, id, image_name, storeview_id=None):
+    def read_image(self, external_id, image_name, storeview_id=None):
         return self._call('product_media.info',
-                          [int(id), image_name, storeview_id, 'id'])
+                          [int(external_id), image_name, storeview_id, 'id'])
 
-    def update_inventory(self, id, data):
+    def update_inventory(self, external_id, data):
         # product_stock.update is too slow
         return self._call('oerp_cataloginventory_stock_item.update',
-                          [int(id), data])
+                          [int(external_id), data])
 
 
 class MagentoBindingProductListener(Component):

--- a/connector_magento/models/product/importer.py
+++ b/connector_magento/models/product/importer.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2013-2017 Camptocamp SA
+# Copyright 2013-2019 Camptocamp SA
 # © 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 

--- a/connector_magento/models/product_category/__init__.py
+++ b/connector_magento/models/product_category/__init__.py
@@ -1,3 +1,2 @@
-# -*- coding: utf-8 -*-
 from . import common
 from . import importer

--- a/connector_magento/models/product_category/common.py
+++ b/connector_magento/models/product_category/common.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2013-2017 Camptocamp SA
+# Copyright 2013-2019 Camptocamp SA
 # © 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
@@ -86,13 +85,14 @@ class ProductCategoryAdapter(Component):
         return self._call('oerp_catalog_category.search',
                           [filters] if filters else [{}])
 
-    def read(self, id, storeview_id=None, attributes=None):
+    def read(self, external_id, storeview_id=None, attributes=None):
         """ Returns the information of a record
 
         :rtype: dict
         """
+        # pylint: disable=method-required-super
         return self._call('%s.info' % self._magento_model,
-                          [int(id), storeview_id, attributes])
+                          [int(external_id), storeview_id, attributes])
 
     def tree(self, parent_id=None, storeview_id=None):
         """ Returns a tree of product categories

--- a/connector_magento/models/product_category/importer.py
+++ b/connector_magento/models/product_category/importer.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2013-2017 Camptocamp SA
+# Copyright 2013-2019 Camptocamp SA
 # © 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 

--- a/connector_magento/models/queue_job/__init__.py
+++ b/connector_magento/models/queue_job/__init__.py
@@ -1,2 +1,1 @@
-# -*- coding: utf-8 -*-
 from . import common

--- a/connector_magento/models/queue_job/common.py
+++ b/connector_magento/models/queue_job/common.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 

--- a/connector_magento/models/sale_order/__init__.py
+++ b/connector_magento/models/sale_order/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from . import common
 from . import importer
 from . import exporter

--- a/connector_magento/models/sale_order/common.py
+++ b/connector_magento/models/sale_order/common.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2013 Guewen Baconnier,Camptocamp SA,Akretion
 # © 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
@@ -278,18 +277,20 @@ class SaleOrderAdapter(Component):
                      }
         return super(SaleOrderAdapter, self).search(arguments)
 
-    def read(self, id, attributes=None):
+    def read(self, external_id, attributes=None):
         """ Returns the information of a record
 
         :rtype: dict
         """
+        # pylint: disable=method-required-super
         record = self._call('%s.info' % self._magento_model,
-                            [id, attributes])
+                            [external_id, attributes])
         return record
 
-    def get_parent(self, id):
-        return self._call('%s.get_parent' % self._magento_model, [id])
+    def get_parent(self, external_id):
+        return self._call('%s.get_parent' % self._magento_model,
+                          [external_id])
 
-    def add_comment(self, id, status, comment=None, notify=False):
+    def add_comment(self, external_id, status, comment=None, notify=False):
         return self._call('%s.addComment' % self._magento_model,
-                          [id, status, comment, notify])
+                          [external_id, status, comment, notify])

--- a/connector_magento/models/sale_order/exporter.py
+++ b/connector_magento/models/sale_order/exporter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 

--- a/connector_magento/models/sale_order/importer.py
+++ b/connector_magento/models/sale_order/importer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 

--- a/connector_magento/models/stock_picking/__init__.py
+++ b/connector_magento/models/stock_picking/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from . import common
 from . import exporter
 from . import tracking_exporter

--- a/connector_magento/models/stock_picking/common.py
+++ b/connector_magento/models/stock_picking/common.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2013-2017 Camptocamp SA
+# Copyright 2013-2019 Camptocamp SA
 # © 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
@@ -90,6 +89,7 @@ class StockPickingAdapter(Component):
 
     def create(self, order_id, items, comment, email, include_comment):
         """ Create a record on the external system """
+        # pylint: disable=method-required-super
         return self._call('%s.create' % self._magento_model,
                           [order_id, items, comment, email, include_comment])
 

--- a/connector_magento/models/stock_picking/exporter.py
+++ b/connector_magento/models/stock_picking/exporter.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2013-2017 Camptocamp SA
+# Copyright 2013-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 import xmlrpc.client
@@ -96,4 +95,5 @@ class MagentoPickingExporter(Component):
             self.binder.bind(external_id, binding)
             # ensure that we store the external ID
             if not odoo.tools.config['test_enable']:
+                # pylint: disable=invalid-commit
                 self.env.cr.commit()  # noqa

--- a/connector_magento/models/stock_picking/tracking_exporter.py
+++ b/connector_magento/models/stock_picking/tracking_exporter.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2013-2017 Camptocamp SA
+# Copyright 2013-2019 Camptocamp SA
 # © 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 

--- a/connector_magento/tests/__init__.py
+++ b/connector_magento/tests/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from . import test_concurrent_sync
 from . import test_export_invoice
 from . import test_export_picking

--- a/connector_magento/tests/common.py
+++ b/connector_magento/tests/common.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2013-2017 Camptocamp SA
+# Copyright 2013-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 # pylint: disable=missing-manifest-dependency
@@ -42,6 +41,7 @@ class MockResponseImage(object):
         self.headers = {'content-type': 'image/jpeg'}
 
     def read(self):
+        # pylint: disable=method-required-super
         return self.resp_data
 
     def getcode(self):

--- a/connector_magento/tests/test_concurrent_sync.py
+++ b/connector_magento/tests/test_concurrent_sync.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2015-2017 Camptocamp SA
+# Copyright 2015-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 import mock

--- a/connector_magento/tests/test_export_invoice.py
+++ b/connector_magento/tests/test_export_invoice.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2013-2017 Camptocamp SA
+# Copyright 2013-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from .common import MagentoSyncTestCase, recorder

--- a/connector_magento/tests/test_export_picking.py
+++ b/connector_magento/tests/test_export_picking.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2014-2017 Camptocamp SA
+# Copyright 2014-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from .common import MagentoSyncTestCase, recorder

--- a/connector_magento/tests/test_export_product_stock.py
+++ b/connector_magento/tests/test_export_product_stock.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2015-2017 Camptocamp SA
+# Copyright 2015-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from .common import MagentoSyncTestCase, recorder

--- a/connector_magento/tests/test_import_metadata.py
+++ b/connector_magento/tests/test_import_metadata.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2013-2017 Camptocamp SA
+# Copyright 2013-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from .common import MagentoTestCase, recorder

--- a/connector_magento/tests/test_import_partner.py
+++ b/connector_magento/tests/test_import_partner.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2015-2017 Camptocamp SA
+# Copyright 2015-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from .common import MagentoSyncTestCase, recorder

--- a/connector_magento/tests/test_import_partner_category.py
+++ b/connector_magento/tests/test_import_partner_category.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2015-2017 Camptocamp SA
+# Copyright 2015-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from .common import MagentoSyncTestCase, recorder

--- a/connector_magento/tests/test_import_product.py
+++ b/connector_magento/tests/test_import_product.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2013-2017 Camptocamp SA
+# Copyright 2013-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from openerp.addons.connector.exception import InvalidDataError

--- a/connector_magento/tests/test_import_product_category.py
+++ b/connector_magento/tests/test_import_product_category.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2013-2017 Camptocamp SA
+# Copyright 2013-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from .common import MagentoSyncTestCase, recorder

--- a/connector_magento/tests/test_import_product_image.py
+++ b/connector_magento/tests/test_import_product_image.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2015-2017 Camptocamp SA
+# Copyright 2015-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 import urllib.request
@@ -13,10 +12,8 @@ from odoo.addons.component.core import WorkContext, Component
 from odoo.addons.component.tests.common import (
     TransactionComponentRegistryCase,
 )
-from odoo.addons.connector_magento import components
-from odoo.addons.connector_magento.models.product.importer import (
-    CatalogImageImporter,
-)
+from .. import components
+from ..models.product.importer import CatalogImageImporter
 from .common import MockResponseImage
 
 # simple square of 4 px filled with green in png, used for the product
@@ -66,7 +63,7 @@ class TestImportProductImage(TransactionComponentRegistryCase):
             _usage = 'backend.adapter'
             _apply_on = 'magento.product.product'
 
-            def get_images(self, id, storeview_id=None):
+            def get_images(self, external_id, storeview_id=None):
                 return [
                     {'exclude': '1',
                      'file': '/i/n/ink-eater-krylon-bombear-destroyed-tee-2.jpg',  # noqa

--- a/connector_magento/tests/test_related_action.py
+++ b/connector_magento/tests/test_related_action.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2014-2017 Camptocamp SA
+# Copyright 2014-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 import mock

--- a/connector_magento/tests/test_sale_order.py
+++ b/connector_magento/tests/test_sale_order.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2014-2017 Camptocamp SA
+# Copyright 2014-2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from collections import namedtuple

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+magento
 vcrpy


### PR DESCRIPTION
Fix the lint errors to get (almost) a green build.
There is still an error regarding the documentation build, but the error came from Odoo I think (see https://github.com/odoo/odoo/issues/28125).

@hugosantosred are you ok to merge this? :) I'll also migrate your PR to Odoo 12.0.